### PR TITLE
Increase slider speed

### DIFF
--- a/DivaHook/src/Components/Input/TouchSliderEmulator.h
+++ b/DivaHook/src/Components/Input/TouchSliderEmulator.h
@@ -35,7 +35,7 @@ namespace DivaHook::Components
 		virtual void OnFocusLost() override;
 
 	private:
-		const float sliderSpeed = 750.0f;
+		const float sliderSpeed = 500.0f;
 		float sliderIncrement;
 
 		TouchSliderState *sliderState;


### PR DESCRIPTION
While playing fast songs such as Blackgold, I noticed I keep missing a couple of max slide bonuses or sometimes the next note due to the slide speed being slow for such a high tempo.