### PR TITLE
GAMO2 DIVALLER Controller support

### DIFF
--- a/DivaHook/src/Input/DirectInput/Ds4/DualShock4.h
+++ b/DivaHook/src/Input/DirectInput/Ds4/DualShock4.h
@@ -6,12 +6,14 @@
 namespace DivaHook::Input
 {
 	// DualShock 4 Wireless Controller Product GUIDs:
-	const GUID GUID_Ds4[2] = 
+	const GUID GUID_Ds4[3] = 
 	{ 
 		// First Generation:  {05C4054C-0000-0000-0000-504944564944}
 		{ 0x05C4054C, 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } },
 		// Second Generation: {09CC054C-0000-0000-0000-504944564944}
 		{ 0x09CC054C, 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } },
+		// GAMO2 DIVALLER: {11140E8F-0000-0000-0000-504944564944}
+		{ 0x11140E8F, 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } },
 	};
 
 	class DualShock4 : public Controller, public IInputDevice


### PR DESCRIPTION
The GAMO2 DIVALLER Controller (https://twitter.com/GamoTwo/status/1129293536187207681) is in closed testing now, and the hardware info is determined.

By default, the controller will run in a DualShock 4 simulating mode on PC, so it's OK to take it just as a DS4.